### PR TITLE
Allow user creation at non-default user container

### DIFF
--- a/ad/resource_active_directory_user.go
+++ b/ad/resource_active_directory_user.go
@@ -43,7 +43,7 @@ func resourceUser() *schema.Resource {
 				ForceNew:  true,
 				Sensitive: true,
 			},
-			"base_dn": {
+			"ou_distinguished_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -71,7 +71,7 @@ func resourceADUserCreate(d *schema.ResourceData, m interface{}) error {
 	email := d.Get("email").(string)
 
 	var dnOfUser string // dnOfUser: distingished names uniquely identifies an entry to AD.
-	if userBaseDn := d.Get("base_dn").(string); userBaseDn != "" {
+	if userBaseDn := d.Get("ou_distinguished_name").(string); userBaseDn != "" {
 		dnOfUser += "CN=" + userName + "," + userBaseDn
 	} else {
 		dnOfUser += "CN=" + userName + ",CN=Users"
@@ -103,7 +103,7 @@ func resourceADUserRead(d *schema.ResourceData, m interface{}) error {
 	userName := firstName + " " + lastName
 
 	var userBaseDn string // baseDn: search base on AD query
-	if baseDn := d.Get("base_dn").(string); baseDn != "" {
+	if baseDn := d.Get("ou_distinguished_name").(string); baseDn != "" {
 		userBaseDn = baseDn
 	} else {
 		userBaseDn += "CN=Users"
@@ -158,7 +158,7 @@ func resourceADUserDelete(d *schema.ResourceData, m interface{}) error {
 	userName := firstName + " " + lastName
 
 	var dnOfUser string
-	if userBaseDn := d.Get("base_dn").(string); userBaseDn != "" {
+	if userBaseDn := d.Get("ou_distinguished_name").(string); userBaseDn != "" {
 		dnOfUser += "CN=" + userName + "," + userBaseDn
 	} else {
 		dnOfUser += "CN=" + userName + ",CN=Users"

--- a/ad/resource_active_directory_user_test.go
+++ b/ad/resource_active_directory_user_test.go
@@ -56,7 +56,7 @@ func testAccCheckAdUserDestroy(n string) resource.TestCheckFunc {
 		client := testAccProvider.Meta().(*ldap.Conn)
 		domain := rs.Primary.Attributes["domain"]
 		var userBaseDn string
-		if baseDn := rs.Primary.Attributes["base_dn"]; baseDn != "" {
+		if baseDn := rs.Primary.Attributes["ou_distinguished_name"]; baseDn != "" {
 			userBaseDn = baseDn
 		} else {
 			domainArr := strings.Split(domain, ".")
@@ -102,7 +102,7 @@ func testAccCheckAdUserExists(n string) resource.TestCheckFunc {
 		client := testAccProvider.Meta().(*ldap.Conn)
 		domain := rs.Primary.Attributes["domain"]
 		var userBaseDn string
-		if baseDn := rs.Primary.Attributes["base_dn"]; baseDn != "" {
+		if baseDn := rs.Primary.Attributes["ou_distinguished_name"]; baseDn != "" {
 			userBaseDn = baseDn
 		} else {
 			domainArr := strings.Split(domain, ".")
@@ -143,7 +143,7 @@ provider "ad" {
 }
 resource "ad_user" "test" {
   domain = "%s"
-	base_dn = "%s"
+	ou_distinguished_name = "%s"
   first_name = "first"
   last_name = "last"
   logon_name = "terraformtest"

--- a/tf-ad-devrc.mk.example
+++ b/tf-ad-devrc.mk.example
@@ -21,7 +21,9 @@ export AD_PASSWORD ?= changeme
 # The following variables are shared across various tests. To ensure all tests
 # succeed, it's probably best to set all of these to valid values.
 export AD_COMPUTER_DOMAIN          ?= base-linux # Active Directory Domain
-export AD_COMPUTER_OU_DISTINGUISHED_NAME	?= 'ou=DevComputers,dc=base-linux'  #AD OU Distinguished name
-export AD_GROUP_OU_DISTINGUISHED_NAME ?= 'ou=DevGroups,dc=base-linux'  #AD OU Distinguished name
+export AD_COMPUTER_OU_DISTINGUISHED_NAME	?= 'ou=DevComputers,dc=base-linux'  #AD Computer OU Distinguished name
+export AD_GROUP_OU_DISTINGUISHED_NAME ?= 'ou=DevGroups,dc=base-linux'  #AD Group OU Distinguished name
+export AD_USER_DOMAIN ?= server.domain
+export AD_USER_BASE_DISTINGUISHED_NAME ?= 'cn=Users,dc=base-linux' #AD User Container Distinguished name 
 
 # vi: filetype=make


### PR DESCRIPTION
This is required for AWS Managed Active Directory implementations, as the AD default "CN=Users" container is not writable for the end-user.